### PR TITLE
Added L2Cache interface

### DIFF
--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -183,3 +183,20 @@ auth_endpoints_v1 = {"refresh_token": v1_auth + "/refresh_token"}
 auth_api_versions = {
     1: auth_endpoints_v1,
 }
+
+
+# -------------------------------
+# ------ L2Cache endpoints
+# -------------------------------
+l2cache_common = "{l2cache_server_address}/schema"
+l2cache_endpoints_common = {
+    # "get_api_versions": schema_common + "/versions",
+}
+
+l2cache_v1 = "{l2cache_server_address}/l2cache/api/v1"
+l2cache_endpoints_v1 = {
+    "l2cache_data": l2cache_v1 + "/table/{table_id}/attributes",
+    "l2cache_meta": l2cache_v1 + "/attribute_metadata",
+}
+
+l2cache_api_versions = {1: l2cache_endpoints_v1}

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -5,6 +5,7 @@ from .emannotationschemas import SchemaClient
 from .infoservice import InfoServiceClient
 from .jsonservice import JSONService
 from .materializationengine import MaterializationClient
+from .l2cache import L2CacheClient
 from .endpoints import default_global_server_address
 
 
@@ -237,6 +238,7 @@ class CAVEclientFull(CAVEclientGlobal):
         self._chunkedgraph = None
         self._annotation = None
         self._materialize = None
+        self._l2cache = None
 
         self.local_server = self.info.local_server()
         av_info = self.info.get_aligned_volume_info()
@@ -250,6 +252,7 @@ class CAVEclientFull(CAVEclientGlobal):
         self._chunkedgraph = None
         self._annotation = None
         self._materialize = None
+        self._l2cache = None
 
     @property
     def datastack_name(self):
@@ -257,10 +260,10 @@ class CAVEclientFull(CAVEclientGlobal):
 
     @property
     def chunkedgraph(self):
-        seg_source = self.info.segmentation_source()
-        table_name = seg_source.split("/")[-1]
-
         if self._chunkedgraph is None:
+            seg_source = self.info.segmentation_source()
+            table_name = seg_source.split("/")[-1]
+
             self._chunkedgraph = ChunkedGraphClient(
                 table_name=table_name,
                 server_address=self.local_server,
@@ -299,3 +302,16 @@ class CAVEclientFull(CAVEclientGlobal):
                 ngl_url=self.info.viewer_site(),
             )
         return self._state
+
+    @property
+    def l2cache(self):
+        if self._l2cache is None:
+            seg_source = self.info.segmentation_source()
+            table_name = seg_source.split("/")[-1]
+
+            self._l2cache = L2CacheClient(
+                server_address=self.local_server,
+                auth_client=self.auth,
+                table_name=table_name,
+            )
+        return self._l2cache

--- a/caveclient/l2cache.py
+++ b/caveclient/l2cache.py
@@ -1,0 +1,108 @@
+from .base import ClientBase, _api_endpoints, handle_response
+from .endpoints import (
+    l2cache_common,
+    l2cache_api_versions,
+    l2cache_endpoints_common,
+    l2cache_endpoints_v1,
+)
+from .auth import AuthClient
+import requests
+import json
+import warnings
+
+server_key = "l2cache_server_address"
+
+
+def L2CacheClient(
+    server_address=None, table_name=None, auth_client=None, api_version="latest"
+):
+    if auth_client is None:
+        auth_client = AuthClient()
+
+    auth_header = auth_client.request_header
+    endpoints, api_version = _api_endpoints(
+        api_version,
+        server_key,
+        server_address,
+        l2cache_endpoints_common,
+        l2cache_api_versions,
+        auth_header,
+    )
+    L2CacheClient = client_mapping[api_version]
+    return L2CacheClient(
+        server_address=server_address,
+        auth_header=auth_header,
+        api_version=api_version,
+        endpoints=endpoints,
+        server_name=server_key,
+        table_name=table_name,
+    )
+
+
+class L2CacheClientLegacy(ClientBase):
+    def __init__(
+        self,
+        server_address,
+        auth_header,
+        api_version,
+        endpoints,
+        server_name,
+        table_name=None,
+    ):
+        super(L2CacheClientLegacy, self).__init__(
+            server_address, auth_header, api_version, endpoints, server_name
+        )
+        warnings.warn("L2Cache is in an experimental stage", UserWarning)
+        self._default_url_mapping["table_id"] = table_name
+
+    @property
+    def default_url_mapping(self):
+        return self._default_url_mapping.copy()
+
+    def get_l2data(self, l2_ids, attributes=None):
+        """Gets the data for L2 ids
+
+        Returns
+        -------
+        dict
+            keys are l2 ids, values are data
+        """
+
+        query_d = {"int64_as_str": False}
+
+        if attributes is not None:
+            query_d["attribute_names"] = ",".join(attributes)
+
+        endpoint_mapping = self.default_url_mapping
+        url = self._endpoints["l2cache_data"].format_map(endpoint_mapping)
+
+        response = self.session.post(
+            url,
+            data=json.dumps(
+                {"l2_ids": l2_ids},
+            ),
+            params=query_d,
+        )
+        return handle_response(response)
+
+    def cache_metadata(self):
+        """Retrieves the meta data for the cache
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        dict
+            keys are attribute names, values are datatypes
+        """
+        endpoint_mapping = self.default_url_mapping
+        url = self._endpoints["l2cache_meta"].format_map(endpoint_mapping)
+        response = self.session.get(url)
+        return handle_response(response)
+
+
+client_mapping = {
+    1: L2CacheClientLegacy,
+    "latest": L2CacheClientLegacy,
+}


### PR DESCRIPTION
Examples:
```
import numpy as np
import datetime
from caveclient import CAVEclient

datastack_name = "flywire_fafb_production"
client = CAVEclient(datastack_name)

l2_ids = [175137943013294113, 175137943013294114, 175137943013294118, 175137943013294119,]
```

```

client.l2cache.get_l2data(l2_ids)
```

```
{'175137943013294113': {},
 '175137943013294114': {'area_nm2': 253952,
  'chunk_intersect_count': [[0, 0, 0], [0, 0, 0]],
  'max_dt_nm': 62,
  'mean_dt_nm': 25.390625,
  'pca': [[-0.18603515625, 0.7392578125, -0.6474609375],
   [-0.2296142578125, -0.67333984375, -0.70263671875],
   [0.95556640625, -0.0178680419921875, -0.294921875]],
  'rep_coord_nm': [535088, 248800, 164880],
  'size_nm3': 4239360},
 '175137943013294118': {'area_nm2': 2432,
  'chunk_intersect_count': [[0, 0, 0], [0, 0, 0]],
  'max_dt_nm': 16,
  'mean_dt_nm': 16.0,
  'pca': [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
  'rep_coord_nm': [536240, 251008, 164920],
  'size_nm3': 10240},
 '175137943013294119': {}}
```

```
client.l2cache.get_l2data(l2_ids, attributes=["size_nm3", "pca", "rep_coord_nm"])
```

```
{'175137943013294113': {},
 '175137943013294114': {'pca': [[-0.18603515625, 0.7392578125, -0.6474609375],
   [-0.2296142578125, -0.67333984375, -0.70263671875],
   [0.95556640625, -0.0178680419921875, -0.294921875]],
  'rep_coord_nm': [535088, 248800, 164880],
  'size_nm3': 4239360},
 '175137943013294118': {'pca': [[1.0, 0.0, 0.0],
   [0.0, 1.0, 0.0],
   [0.0, 0.0, 1.0]],
  'rep_coord_nm': [536240, 251008, 164920],
  'size_nm3': 10240},
 '175137943013294119': {}}
```

```
client.l2cache.cache_metadata()
```
```
{'area_nm2': "<class 'numpy.uint32'>",
 'chunk_intersect_count': "<class 'numpy.uint16'>",
 'max_dt_nm': "<class 'numpy.uint16'>",
 'mean_dt_nm': "<class 'numpy.float16'>",
 'pca': "<class 'numpy.float16'>",
 'rep_coord_nm': "<class 'numpy.uint64'>",
 'size_nm3': "<class 'numpy.uint32'>"}
```
