### PR TITLE
L2 cache JSON encoder

### DIFF
--- a/caveclient/annotationengine.py
+++ b/caveclient/annotationengine.py
@@ -2,6 +2,7 @@ from .base import (
     ClientBaseWithDataset,
     ClientBaseWithDatastack,
     ClientBase,
+    BaseEncoder,
     _api_versions,
     _api_endpoints,
     handle_response,
@@ -18,17 +19,6 @@ import pandas as pd
 from typing import Iterable, Mapping
 
 SERVER_KEY = "ae_server_address"
-
-
-class AEEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        if isinstance(obj, np.uint64):
-            return int(obj)
-        if isinstance(obj, (datetime, date)):
-            return obj.isoformat()
-        return json.JSONEncoder.default(self, obj)
 
 
 def AnnotationClient(
@@ -388,7 +378,7 @@ class AnnotationClientV2(ClientBase):
 
         response = self.session.post(
             url,
-            data=json.dumps(data, cls=AEEncoder),
+            data=json.dumps(data, cls=BaseEncoder),
             headers={"Content-Type": "application/json"},
         )
         return handle_response(response)
@@ -585,7 +575,7 @@ class AnnotationClientV2(ClientBase):
 
         response = self.session.delete(
             url,
-            data=json.dumps(data, cls=AEEncoder),
+            data=json.dumps(data, cls=BaseEncoder),
             headers={"Content-Type": "application/json"},
         )
         return handle_response(response)

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -13,6 +13,8 @@ class BaseEncoder(json.JSONEncoder):
             return obj.tolist()
         if isinstance(obj, np.uint64):
             return int(obj)
+        if isinstance(obj, np.int64):
+            return int(obj)
         if isinstance(obj, (datetime.datetime, datetime.date)):
             return obj.isoformat()
         return json.JSONEncoder.default(self, obj)

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -3,6 +3,18 @@ import requests
 import json
 import logging
 import webbrowser
+import numpy as np
+import datetime
+
+class CGEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.uint64):
+            return int(obj)
+        if isinstance(obj, (datetime.datetime, datetime.date)):
+            return obj.isoformat()
+        return json.JSONEncoder.default(self, obj)
 
 
 class AuthException(Exception):

--- a/caveclient/base.py
+++ b/caveclient/base.py
@@ -6,7 +6,8 @@ import webbrowser
 import numpy as np
 import datetime
 
-class CGEncoder(json.JSONEncoder):
+
+class BaseEncoder(json.JSONEncoder):
     def default(self, obj):
         if isinstance(obj, np.ndarray):
             return obj.tolist()

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -12,7 +12,7 @@ from .endpoints import (
     chunkedgraph_endpoints_common,
     default_global_server_address,
 )
-from .base import _api_endpoints, _api_versions, ClientBase, handle_response, CGEncoder
+from .base import _api_endpoints, _api_versions, ClientBase, handle_response
 from .auth import AuthClient
 from typing import Iterable
 from urllib.parse import urlencode
@@ -20,6 +20,17 @@ import networkx as nx
 
 
 SERVER_KEY = "cg_server_address"
+
+
+class CGEncoder(json.JSONEncoder):
+    def default(self, obj):
+        if isinstance(obj, np.ndarray):
+            return obj.tolist()
+        if isinstance(obj, np.uint64):
+            return int(obj)
+        if isinstance(obj, (datetime.datetime, datetime.date)):
+            return obj.isoformat()
+        return json.JSONEncoder.default(self, obj)
 
 
 def package_bounds(bounds):

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -12,7 +12,13 @@ from .endpoints import (
     chunkedgraph_endpoints_common,
     default_global_server_address,
 )
-from .base import _api_endpoints, _api_versions, ClientBase, handle_response
+from .base import (
+    _api_endpoints,
+    _api_versions,
+    ClientBase,
+    BaseEncoder,
+    handle_response,
+)
 from .auth import AuthClient
 from typing import Iterable
 from urllib.parse import urlencode
@@ -20,17 +26,6 @@ import networkx as nx
 
 
 SERVER_KEY = "cg_server_address"
-
-
-class CGEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        if isinstance(obj, np.uint64):
-            return int(obj)
-        if isinstance(obj, (datetime.datetime, datetime.date)):
-            return obj.isoformat()
-        return json.JSONEncoder.default(self, obj)
 
 
 def package_bounds(bounds):
@@ -250,7 +245,7 @@ class ChunkedGraphClientV1(ClientBase):
         endpoint_mapping["root_ids"] = root_ids
         url = self._endpoints["tabular_change_log"].format_map(endpoint_mapping)
         params = {"filtered": filtered}
-        data = json.dumps({"root_ids": root_ids}, cls=CGEncoder)
+        data = json.dumps({"root_ids": root_ids}, cls=BaseEncoder)
 
         response = self.session.get(url, data=data, params=params)
         res_dict = handle_response(response)
@@ -309,7 +304,7 @@ class ChunkedGraphClientV1(ClientBase):
         params = {"priority": False}
         response = self.session.post(
             url,
-            data=json.dumps(data, cls=CGEncoder),
+            data=json.dumps(data, cls=BaseEncoder),
             params=params,
             headers={"Content-Type": "application/json"},
         )
@@ -386,7 +381,7 @@ class ChunkedGraphClientV1(ClientBase):
 
         response = self.session.post(
             url,
-            data=json.dumps(nodes, cls=CGEncoder),
+            data=json.dumps(nodes, cls=BaseEncoder),
             params=query_d,
             headers={"Content-Type": "application/json"},
         )
@@ -588,7 +583,9 @@ class ChunkedGraphClientV1(ClientBase):
             query_d = None
         data = {"node_ids": root_ids}
         r = handle_response(
-            self.session.post(url, data=json.dumps(data, cls=CGEncoder), params=query_d)
+            self.session.post(
+                url, data=json.dumps(data, cls=BaseEncoder), params=query_d
+            )
         )
         return np.array(r["is_latest"], np.bool)
 
@@ -609,7 +606,7 @@ class ChunkedGraphClientV1(ClientBase):
 
         data = {"node_ids": root_ids}
         r = handle_response(
-            self.session.post(url, data=json.dumps(data, cls=CGEncoder))
+            self.session.post(url, data=json.dumps(data, cls=BaseEncoder))
         )
 
         return np.array(
@@ -648,7 +645,7 @@ class ChunkedGraphClientV1(ClientBase):
         data = {"root_ids": np.array(root_ids, dtype=np.uint64)}
         url = self._endpoints["past_id_mapping"].format_map(endpoint_mapping)
         r = handle_response(
-            self.session.get(url, data=json.dumps(data, cls=CGEncoder), params=params)
+            self.session.get(url, data=json.dumps(data, cls=BaseEncoder), params=params)
         )
 
         # Convert id keys as strings to ints

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -12,7 +12,7 @@ from .endpoints import (
     chunkedgraph_endpoints_common,
     default_global_server_address,
 )
-from .base import _api_endpoints, _api_versions, ClientBase, handle_response
+from .base import _api_endpoints, _api_versions, ClientBase, handle_response, CGEncoder
 from .auth import AuthClient
 from typing import Iterable
 from urllib.parse import urlencode
@@ -20,17 +20,6 @@ import networkx as nx
 
 
 SERVER_KEY = "cg_server_address"
-
-
-class CGEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        if isinstance(obj, np.uint64):
-            return int(obj)
-        if isinstance(obj, (datetime.datetime, datetime.date)):
-            return obj.isoformat()
-        return json.JSONEncoder.default(self, obj)
 
 
 def package_bounds(bounds):

--- a/caveclient/jsonservice.py
+++ b/caveclient/jsonservice.py
@@ -1,4 +1,9 @@
-from .base import ClientBase, _api_versions, _api_endpoints, handle_response
+from .base import (
+    ClientBase,
+    _api_versions,
+    _api_endpoints,
+    handle_response,
+)
 from .auth import AuthClient
 from .endpoints import (
     jsonservice_common,

--- a/caveclient/l2cache.py
+++ b/caveclient/l2cache.py
@@ -1,4 +1,4 @@
-from .base import ClientBase, _api_endpoints, handle_response
+from .base import ClientBase, _api_endpoints, handle_response, CGEncoder
 from .endpoints import (
     l2cache_common,
     l2cache_api_versions,
@@ -80,6 +80,7 @@ class L2CacheClientLegacy(ClientBase):
             url,
             data=json.dumps(
                 {"l2_ids": l2_ids},
+                cls=CGEncoder,
             ),
             params=query_d,
         )

--- a/caveclient/l2cache.py
+++ b/caveclient/l2cache.py
@@ -1,4 +1,4 @@
-from .base import ClientBase, _api_endpoints, handle_response, CGEncoder
+from .base import ClientBase, _api_endpoints, handle_response, BaseEncoder
 from .endpoints import (
     l2cache_common,
     l2cache_api_versions,
@@ -80,7 +80,7 @@ class L2CacheClientLegacy(ClientBase):
             url,
             data=json.dumps(
                 {"l2_ids": l2_ids},
-                cls=CGEncoder,
+                cls=BaseEncoder,
             ),
             params=query_d,
         )

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -9,6 +9,7 @@ from .base import (
     ClientBaseWithDataset,
     ClientBaseWithDatastack,
     ClientBase,
+    BaseEncoder,
     _api_versions,
     _api_endpoints,
     handle_response,
@@ -60,19 +61,6 @@ def concatenate_position_columns(df, inplace=False):
             else:
                 df2 = df2.drop(gl, axis=1, inplace=inplace)
     return df2
-
-
-class MEEncoder(json.JSONEncoder):
-    def default(self, obj):
-        if isinstance(obj, np.ndarray):
-            return obj.tolist()
-        if isinstance(obj, np.uint64):
-            return int(obj)
-        if isinstance(obj, np.int64):
-            return int(obj)
-        if isinstance(obj, (datetime, date)):
-            return obj.isoformat()
-        return json.JSONEncoder.default(self, obj)
 
 
 def convert_timestamp(ts: datetime):
@@ -582,7 +570,7 @@ class MaterializatonClientV2(ClientBase):
 
         response = self.session.post(
             url,
-            data=json.dumps(data, cls=MEEncoder),
+            data=json.dumps(data, cls=BaseEncoder),
             headers={"Content-Type": "application/json", "Accept-Encoding": encoding},
             params=query_args,
             stream=~return_df,
@@ -682,7 +670,7 @@ class MaterializatonClientV2(ClientBase):
 
         response = self.session.post(
             url,
-            data=json.dumps(data, cls=MEEncoder),
+            data=json.dumps(data, cls=BaseEncoder),
             headers={"Content-Type": "application/json", "Accept-Encoding": encoding},
             params=query_args,
             stream=~return_df,
@@ -984,7 +972,7 @@ class MaterializatonClientV2(ClientBase):
         with TimeIt("query materialize"):
             response = self.session.post(
                 url,
-                data=json.dumps(data, cls=MEEncoder),
+                data=json.dumps(data, cls=BaseEncoder),
                 headers={
                     "Content-Type": "application/json",
                     "Accept-Encoding": encoding,


### PR DESCRIPTION
Various clients all have to have numpy encoders for the json dumps, however they all seem to be copy/paste. This adds a generic one to .base and uses it for the l2client.

Is there any reason to not move all of the other encoders to the same common one? I don't see any custom logic in any of them right now.