### PR TITLE
Fixed timestamp conversion in get_root_timestamps

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -627,10 +627,7 @@ class ChunkedGraphClientV1(ClientBase):
         )
 
         return np.array(
-            [
-                pytz.UTC.localize(datetime.datetime.fromtimestamp(ts))
-                for ts in r["timestamp"]
-            ]
+            [datetime.datetime.fromtimestamp(ts, pytz.UTC) for ts in r["timestamp"]]
         )
 
     def get_past_ids(self, root_ids, timestamp_past=None, timestamp_future=None):


### PR DESCRIPTION
Bug: Timestamps from the PCG are converted to a datetime without timezone information and then simply tagged as UTC. This way, the datetime conversion depended on ones location. 