### PR TITLE
Dataframe attributes

### DIFF
--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -1095,7 +1095,7 @@ class MaterializatonClientV2(ClientBase):
                 limit=limit,
                 live_query=timestamp is not None,
                 timestamp=string_format_timestamp(timestamp),
-                materialization_version=materialization_version,
+                materialization_version=None,
             )
             df.attrs.update(attrs)
 


### PR DESCRIPTION
This PR makes two additions to the materialization client:

1) Query and table metadata is optionally attached to a query dataframe using the `df.attrs` dictionary that pandas suggests. By default, metadata is attached. This includes all table metadata, as well as any query filters, and the materialization version or live query timestamp.

2) Added a `timestamp="now"` to the convert_timestamp parser, so that live query can be used without as much datetime  boilerplate. The metadata makes this more meaning, because the actual value of the live query timestamp is included and can be trivially passed to subsequent calls.