### PR TITLE
Reference merge

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -701,7 +701,7 @@ class ChunkedGraphClientV1(ClientBase):
             timestamp (datetime.dateime, optional): timestamp to check whether these IDs are valid root_ids. Defaults to None (assumes now).
 
         Returns:
-            np.array[np.Boolean]: boolean array of whether these are valid root_ids
+            np.array[bool]: boolean array of whether these are valid root_ids
         """
         root_ids = root_id_int_list_check(root_ids, make_unique=False)
 
@@ -720,7 +720,7 @@ class ChunkedGraphClientV1(ClientBase):
                 url, data=json.dumps(data, cls=BaseEncoder), params=query_d
             )
         )
-        return np.array(r["is_latest"], np.bool)
+        return np.array(r["is_latest"], bool)
 
     def get_root_timestamps(self, root_ids):
         """Retrieves timestamps when roots where created.

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -1233,6 +1233,9 @@ class MaterializatonClientV2(ClientBase):
             return df
 
     def _assemble_attributes(self, tables, suffixes=None, **kwargs):
+        if isinstance(tables, str):
+            tables = [tables]
+
         join_query = len(tables) > 1
 
         attrs = {

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -511,8 +511,8 @@ class MaterializatonClientV2(ClientBase):
             target_table = md["reference_table"]
 
         if target_table is not None:
-            tables = [[table, "target_id"], [md["reference_table"], id]]
-            suffixes = ("", "_ref")
+            tables = [[table, "target_id"], [md["reference_table"], "id"]]
+            suffixes = ("", "ref")
         else:
             tables = [table]
             suffixes = None

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -508,7 +508,7 @@ class MaterializatonClientV2(ClientBase):
                 datastack_name=datastack_name,
                 version=materialization_version,
             )
-            target_table = md["reference_table"]
+            target_table = md["reference_table"] if len(md["reference_table"])>1 else None
 
         if target_table is not None:
             tables = [[table, "target_id"], [md["reference_table"], "id"]]

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -512,7 +512,7 @@ class MaterializatonClientV2(ClientBase):
             if md["reference_table"] is None:
                 target_table = None
             else:
-                if len(md["reference_table"] )==0:
+                if len(md["reference_table"]) == 0:
                     target_table = None
                 else:
                     target_table = md["reference_table"]
@@ -647,8 +647,7 @@ class MaterializatonClientV2(ClientBase):
 
             if metadata:
                 attrs = self._assemble_attributes(
-                    table,
-                    join_query=False,
+                    tables,
                     filters={
                         "inclusive": filter_in_dict,
                         "exclusive": filter_out_dict,
@@ -769,7 +768,6 @@ class MaterializatonClientV2(ClientBase):
             if metadata:
                 attrs = self._assemble_attributes(
                     tables,
-                    join_query=True,
                     suffixes=suffixes,
                     filters={
                         "inclusive": filter_in_dict,
@@ -1234,13 +1232,15 @@ class MaterializatonClientV2(ClientBase):
         else:
             return df
 
-    def _assemble_attributes(self, tables, join_query, suffixes=None, **kwargs):
+    def _assemble_attributes(self, tables, suffixes=None, **kwargs):
+        join_query = len(tables) > 1
+
         attrs = {
             "datastack_name": self.datastack_name,
         }
         if not join_query:
             attrs["join_query"] = False
-            meta = self.get_table_metadata(tables)
+            meta = self.get_table_metadata(tables[0])
             for k, v in meta.items():
                 if re.match("^table", k):
                     attrs[k] = v

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -508,8 +508,11 @@ class MaterializatonClientV2(ClientBase):
                 datastack_name=datastack_name,
                 version=materialization_version,
             )
-            target_table = md["reference_table"] if len(md["reference_table"])>1 else None
-
+            target_table = (
+                md["reference_table"] if len(md["reference_table"]) > 1 else None
+            )
+        else:
+            target_table = None
         if target_table is not None:
             tables = [[table, "target_id"], [md["reference_table"], "id"]]
             suffixes = ("", "ref")

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -4,6 +4,7 @@ from typing import ValuesView
 
 from numpy.lib.function_base import iterable
 from numpy.lib.twodim_base import _trilu_indices_form_dispatcher
+from responses import target
 import caveclient
 from .base import (
     ClientBaseWithDataset,
@@ -508,9 +509,13 @@ class MaterializatonClientV2(ClientBase):
                 datastack_name=datastack_name,
                 version=materialization_version,
             )
-            target_table = (
-                md["reference_table"] if len(md["reference_table"]) > 1 else None
-            )
+            if md["reference_table"] is None:
+                target_table = None
+            else:
+                if len(md["reference_table"] )==0:
+                    target_table = None
+                else:
+                    target_table = md["reference_table"]
         else:
             target_table = None
         if target_table is not None:

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -397,7 +397,7 @@ class TestChunkedgraph:
         root_id_list = [164471821834388001, 864691135776832352]
         root_ids = np.array(root_id_list, dtype=np.uint64)
         is_latest_list = [False, True]
-        is_latest = np.array(is_latest_list, np.bool)
+        is_latest = np.array(is_latest_list, bool)
 
         responses.add(
             responses.POST,

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -59,6 +59,21 @@ class TestMatclient:
         "voxel_resolution": [4.0, 4.0, 40.0],
     }
 
+    synapse_metadata = {
+        "aligned_volume": test_info["aligned_volume"],
+        "id": 474,
+        "schema": "synapse",
+        "valid": True,
+        "created": "2021-04-29T05:58:42.196350",
+        "table_name": test_info["synapse_table"],
+        "description": "test synapse table",
+        "flat_segmentation_source": "",
+        "schema_type": "synapse",
+        "user_id": "56",
+        "reference_table": "",
+        "voxel_resolution": [4.0, 4.0, 40.0],
+    }
+
     @responses.activate
     def test_matclient(self, myclient, mocker):
         endpoint_mapping = self.default_mapping
@@ -72,6 +87,10 @@ class TestMatclient:
         responses.add(responses.GET, url=versionurl, json=[1], status=200)
 
         url = self.endpoints["simple_query"].format_map(endpoint_mapping)
+        syn_md_url = self.endpoints["metadata"].format_map(endpoint_mapping)
+
+        responses.add(responses.GET, url=syn_md_url, json=self.synapse_metadata)
+
         query_d = {"return_pyarrow": True, "split_positions": True}
         query_string = urlencode(query_d)
         url = url + "?" + query_string

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -70,7 +70,7 @@ class TestMatclient:
         "flat_segmentation_source": "",
         "schema_type": "synapse",
         "user_id": "56",
-        "reference_table": "",
+        "reference_table": None,
         "voxel_resolution": [4.0, 4.0, 40.0],
     }
 


### PR DESCRIPTION
adds a flag to allow automatic merging of reference annotations.

Choices made.. automatically add a "ref" suffix to the reference table columns that overlap (this will make the reference table id "id_ref" in the dataframe). 

Make this default True: This means metadata needs to be queried for every table even if not a reference, but i've enabled caching of this information now so it should be a one time cost per session-table. 

Haven't addressed join query as it would be more complicated.