### PR TITLE
Set info cache from dict

### DIFF
--- a/caveclient/infoservice.py
+++ b/caveclient/infoservice.py
@@ -31,6 +31,7 @@ def InfoServiceClient(
     pool_maxsize=None,
     pool_block=None,
     over_client=None,
+    info_cache=None,
 ):
     if server_address is None:
         server_address = default_global_server_address
@@ -61,6 +62,7 @@ def InfoServiceClient(
         pool_maxsize=pool_maxsize,
         pool_block=pool_block,
         over_client=over_client,
+        info_cache=info_cache,
     )
 
 
@@ -78,6 +80,7 @@ class InfoServiceClientV2(ClientBaseWithDatastack):
         pool_maxsize=None,
         pool_block=None,
         over_client=None,
+        info_cache=None,
     ):
         super(InfoServiceClientV2, self).__init__(
             server_address,
@@ -92,7 +95,11 @@ class InfoServiceClientV2(ClientBaseWithDatastack):
             pool_block=pool_block,
             over_client=over_client,
         )
-        self.info_cache = dict()
+        if not info_cache:
+            self.info_cache = dict()
+        else:
+            self.info_cache = info_cache
+
         if datastack_name is not None:
             ds_info = self.get_datastack_info(datastack_name=datastack_name)
             self._aligned_volume_name = ds_info["aligned_volume"]["name"]

--- a/caveclient/tools/caching.py
+++ b/caveclient/tools/caching.py
@@ -1,0 +1,38 @@
+from caveclient import CAVEclient
+from cachetools import TTLCache, cached, keys
+
+info_cache_cache = TTLCache(maxsize=32, ttl=3600)
+
+
+def server_key(datastack_name, server_address, **kwargs):
+    key = keys.hashkey(datastack_name, server_address)
+    return key
+
+
+@cached(info_cache_cache, key=server_key)
+def stored_info_cache(datastack_name, server_address, **kwargs):
+    client = CAVEclient(
+        datastack_name=datastack_name, server_address=server_address, **kwargs
+    )
+    return client.info.info_cache
+
+
+def CachedClient(datastack_name, server_address=None, **kwargs):
+    """Initialize a CAVE client using a cached version of the info service information with a 1 hour time to live.
+
+    Parameters
+    ----------
+    datastack_name : string
+        Datastack name
+    server_address : string or None
+        Local server address
+    All additional keyword arguments are passed to the CAVEclient.
+
+    Returns
+    -------
+    CAVEclient
+    """
+    kwargs["info_cache"] = stored_info_cache(datastack_name, server_address, **kwargs)
+    return CAVEclient(
+        datastack_name=datastack_name, server_address=server_address, **kwargs
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ipython
 networkx
 jsonschema
 attrs>=21.3.0
+cachetools>=4


### PR DESCRIPTION
Small fix to allow info_cache to be passed to the caveclient.

The idea here is that if one is working in a programmatic situation where many cave clients are being initialized all the time, the info cache could itself be cached (e.g. an LRU cache hashed by data stack and server name with an expiration time of an hour), avoiding an extra lookup roundtrip and an extra hit on the info service to get the same dict upon each caveclient initialization.