### PR TITLE
Added user operation interface

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -268,6 +268,42 @@ class ChunkedGraphClientV1(ClientBase):
 
         return handle_response(response)
 
+    def get_user_operations(
+        self,
+        user_id: int,
+        include_undo: bool = True,
+        timestamp_start: datetime.datetime = None,
+        timestamp_end: datetime.datetime = None,
+    ):
+        """get operation details for a user_id
+
+        Args:
+            user_id (int): userID to query (use 0 for all users [admin only])
+            include_undo (bool, optional): whether to include undos. Defaults to True.
+            timestamp_start (datetime.datetime, optional): timestamp to start filter (UTC). Defaults to None.
+            timestamp_end (datetime.datetime, optional): timestamp to end filter (UTC). Defaults to None.
+        """
+        endpoint_mapping = self.default_url_mapping
+
+        url = self._endpoints["user_operations"].format_map(endpoint_mapping)
+        params = {"include_undo": include_undo}
+
+        if user_id > 0:
+            params = {"user_id": user_id}
+        if timestamp_start is not None:
+            params.update(
+                package_timestamp(
+                    self._process_timestamp(timestamp_start), "start_time"
+                )
+            )
+        if timestamp_end is not None:
+            params.update(
+                package_timestamp(self._process_timestamp(timestamp_end), "end_time")
+            )
+        response = self.session.get(url, params=params)
+
+        return handle_response(response)
+
     def get_tabular_change_log(self, root_ids, filtered=True):
         """Get a detailed changelog for neurons
 

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -271,17 +271,17 @@ class ChunkedGraphClientV1(ClientBase):
     def get_user_operations(
         self,
         user_id: int,
+        timestamp_start: datetime.datetime,
         include_undo: bool = True,
-        timestamp_start: datetime.datetime = None,
         timestamp_end: datetime.datetime = None,
     ):
         """get operation details for a user_id
 
         Args:
             user_id (int): userID to query (use 0 for all users [admin only])
+            timestamp_start (datetime.datetime, optional): timestamp to start filter (UTC).
             include_undo (bool, optional): whether to include undos. Defaults to True.
-            timestamp_start (datetime.datetime, optional): timestamp to start filter (UTC). Defaults to None.
-            timestamp_end (datetime.datetime, optional): timestamp to end filter (UTC). Defaults to None.
+            timestamp_end (datetime.datetime, optional): timestamp to end filter (UTC). Defaults to now.
         """
         endpoint_mapping = self.default_url_mapping
 
@@ -302,7 +302,12 @@ class ChunkedGraphClientV1(ClientBase):
             )
         response = self.session.get(url, params=params)
 
-        return handle_response(response)
+        d = handle_response(response)
+        df = pd.DataFrame(d)
+        df["timestamp"] = df["timestamp"].map(
+            lambda x: datetime.datetime.fromtimestamp(x / 1000, pytz.UTC)
+        )
+        return df
 
     def get_tabular_change_log(self, root_ids, filtered=True):
         """Get a detailed changelog for neurons

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -115,6 +115,7 @@ chunkedgraph_endpoints_v1 = {
     "handle_lineage_graph": pcg_v1 + "/table/{table_id}/lineage_graph_multiple",
     "past_id_mapping": pcg_v1 + "/table/{table_id}/past_id_mapping",
     "operation_details": pcg_v1 + "/table/{table_id}/operation_details",
+    "user_operations": pcg_v1 + "/table/{table_id}/user_operations",
     "is_latest_roots": pcg_v1 + "/table/{table_id}/is_latest_roots",
     "root_timestamps": pcg_v1 + "/table/{table_id}/root_timestamps",
     "delta_roots": pcg_v1 + "/table/{table_id}/delta_roots",


### PR DESCRIPTION
The addressed endpoint uses `admin_view` permissions. We are planning to change that to group-based permissions; but for the time being this function will only be useful for users with admin permissions on any dataset or higher.