### PR TITLE
adding methods to aid in token setup

### DIFF
--- a/caveclient/auth.py
+++ b/caveclient/auth.py
@@ -35,7 +35,7 @@ def write_token(token, filepath, key, overwrite=True):
 
     secrets[key] = token
 
-    secret_dir, _ = os.path.split(filepath)
+    secret_dir = os.path.dirname(filepath)
     if not os.path.exists(secret_dir):
         full_dir = os.path.expanduser(secret_dir)
         os.makedirs(full_dir)
@@ -169,7 +169,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
                 if you want to create a new token, or have no token use ```self.get_new_token``` instead
                 or use this function with the keyword argument make_new=True"""
         print(txt)
-        if open is True:
+        if open:
             webbrowser.open(auth_url)
         return None
 
@@ -209,7 +209,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
                 Note: If you need to save or load multiple tokens, please read the documentation for details.
                 Warning! Creating a new token by finishing step 2 will invalidate the previous token!"""
         print(txt)
-        if open is True:
+        if open:
             webbrowser.open(auth_url)
         return None
 

--- a/caveclient/auth.py
+++ b/caveclient/auth.py
@@ -8,6 +8,7 @@ import webbrowser
 import requests
 import json
 import logging
+import time
 
 logger = logging.getLogger(__name__)
 
@@ -19,6 +20,28 @@ default_token_file = f"{default_token_location}/{default_token_name}"
 deprecated_token_files = [
     f"{default_token_location}/{f}" for f in deprecated_token_names
 ]
+
+
+def write_token(token, filepath, key, overwrite=True):
+
+    if os.path.exists(filepath):
+        with open(filepath, "r") as f:
+            secrets = json.load(f)
+
+        if overwrite is False and key in secrets:
+            raise ValueError(f'Key "{key}" already exists in token file "{filepath}"')
+    else:
+        secrets = {}
+
+    secrets[key] = token
+
+    secret_dir, _ = os.path.split(filepath)
+    if not os.path.exists(secret_dir):
+        full_dir = os.path.expanduser(secret_dir)
+        os.makedirs(full_dir)
+
+    with open(filepath, "w") as f:
+        json.dump(secrets, f)
 
 
 class AuthClient(object):
@@ -52,10 +75,10 @@ class AuthClient(object):
         if token_file is None:
             server = urllib.parse.urlparse(server_address).netloc
             server_file = server + "-cave-secret.json"
-            server_file_path = os.path.join(default_token_location, server_file)
-            server_file_path = os.path.expanduser(server_file_path)
-            if os.path.isfile(server_file_path):
-                token_file = server_file_path
+            self._server_file_path = os.path.join(default_token_location, server_file)
+            self._server_file_path = os.path.expanduser(self._server_file_path)
+            if os.path.isfile(self._server_file_path):
+                token_file = self._server_file_path
             else:
                 token_file = default_token_file
         self._token_file = os.path.expanduser(token_file)
@@ -118,6 +141,54 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
             token = None
         return token
 
+    def setup_token(self, make_new=True, open=True):
+        """Currently, returns instructions for getting your auth token based on the current settings and saving it to the local environment.
+        New OAuth tokens are currently not able to be retrieved programmatically.
+
+        Parameters
+        ----------
+        make_new : bool, optional
+            If True, will make a new token, else prompt you to open a page to
+            retrieve an existing token.
+        open : bool, optional
+            If True, opens a web browser to the web page where you can retrieve a token.
+        """
+        if make_new:
+            return self.get_new_token(open=open)
+
+        auth_url = auth_endpoints_v1["get_tokens"].format_map(
+            self._default_endpoint_mapping
+        )
+        txt = f"""Tokens need to be acquired by hand. Please follow the following steps:
+                1) Go to: {auth_url} to view a list of your existing tokens.
+                2) Log in with your Google credentials copy one of the tokens from the dictionary (the string under the key 'token').
+                3a) Save it to your computer with: client.auth.save_token(token="PASTE_YOUR_TOKEN_HERE")
+                or
+                3b) Set it for the current session only with client.auth.token = "PASTE_YOUR_TOKEN_HERE"
+                Note: If you need to save or load multiple tokens, please read the documentation for details.
+                if you want to create a new token, or have no token use ```self.get_new_token``` instead
+                or use this function with the keyword argument make_new=True"""
+        print(txt)
+        if open is True:
+            webbrowser.open(auth_url)
+        return None
+
+    def get_tokens(self):
+        """Get the tokens setup for this users
+
+        Returns
+        -------
+        list[dict]:
+            a list of dictionary of tokens, each with the keys
+            "id": the id of this token
+            "token": the token (str)
+            "user_id": the users id (should be your ID)
+        """
+        url = auth_endpoints_v1["get_tokens"].format_map(self._default_endpoint_mapping)
+        response = requests.Session().get(url, headers=self.request_header)
+
+        return handle_response(response)
+
     def get_new_token(self, open=False):
         """Currently, returns instructions for getting a new token based on the current settings and saving it to the local environment. New OAuth tokens are currently not able to be retrieved programmatically.
 
@@ -149,6 +220,7 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
         overwrite=False,
         token_file=None,
         switch_token=True,
+        write_to_server_file=True,
     ):
         """Conveniently save a token in the correct format.
 
@@ -173,6 +245,9 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
             Path to the token file, by default None. If None, uses the default file location specified above.
         switch_token : bool, optional
             If True, switch the auth client over into using the new token, by default True
+        write_to_server_file: bool, optional
+            If True, will write token to a server specific file to support this machine
+            interacting with multiple auth servers.
         """
         if token is None:
             token = self.token
@@ -185,26 +260,9 @@ rename to 'cave-secret.json' or 'SERVER_ADDRESS-cave-secret.json"""
         if save_token_file is None:
             raise ValueError("No token file is set")
 
-        if os.path.exists(save_token_file):
-            with open(save_token_file, "r") as f:
-                secrets = json.load(f)
-
-            if overwrite is False and token_key in secrets:
-                raise ValueError(
-                    f'Key "{token_key}" already exists in token file "{save_token_file}"'
-                )
-        else:
-            secrets = {}
-
-        secrets[token_key] = token
-
-        secret_dir, _ = os.path.split(save_token_file)
-        if not os.path.exists(secret_dir):
-            full_dir = os.path.expanduser(secret_dir)
-            os.makedirs(full_dir)
-
-        with open(save_token_file, "w") as f:
-            json.dump(secrets, f)
+        write_token(token, save_token_file, token_key, overwrite=overwrite)
+        if write_to_server_file:
+            write_token(token, self._server_file_path, token_key, overwrite=overwrite)
 
         if switch_token:
             self._token = token

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -185,6 +185,7 @@ v1_auth = "{auth_server_address}/auth/api/v1"
 auth_endpoints_v1 = {
     "refresh_token": v1_auth + "/refresh_token",
     "create_token": v1_auth + "/create_token",
+    "get_token": v1_auth + "/user/token",
     "get_users": v1_auth + "/user",
     "get_group_users": v1_auth + "/group/{group_id}/user",
 }

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -4,8 +4,7 @@ import pytz
 import pandas as pd
 from IPython.display import HTML
 from .timeit import TimeIt
-from typing import Union
-from collections.abc import Iterable
+from typing import Union, Iterable
 import itertools
 import pyarrow as pa
 from datetime import datetime, timezone
@@ -33,8 +32,8 @@ def convert_position_columns(df, given_resolution, desired_resolution):
 
     Args:
         df (pd.DataFrame): dataframe to alter
-        given_resolution (Iterable(float)): what the given resolution is
-        desired_resoultion (Iterable(float)): what the desired resolution is
+        given_resolution (Iterable[float]): what the given resolution is
+        desired_resoultion (Iterable[float]): what the desired resolution is
 
     Returns:
         pd.DataFrame: [description]

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -21,6 +21,7 @@ from .base import (
 )
 from cachetools import cached, TTLCache
 import logging
+
 logger = logging.getLogger(__name__)
 
 SERVER_KEY = "me_server_address"
@@ -374,8 +375,7 @@ class MaterializatonClientV2(ClientBase):
         datetime.datetime
             Datetime when the materialization version was frozen.
         """
-        meta = self.get_version_metadata(
-            version=version, datastack_name=datastack_name)
+        meta = self.get_version_metadata(version=version, datastack_name=datastack_name)
         return convert_timestamp(meta["time_stamp"])
 
     @cached(cache=TTLCache(maxsize=100, ttl=60 * 60 * 12))
@@ -586,8 +586,7 @@ class MaterializatonClientV2(ClientBase):
         """
         if timestamp is not None:
             if materialization_version is not None:
-                raise ValueError(
-                    "cannot specify timestamp and materialization version")
+                raise ValueError("cannot specify timestamp and materialization version")
             else:
                 return self.live_query(
                     table,
@@ -634,8 +633,7 @@ class MaterializatonClientV2(ClientBase):
         response = self.session.post(
             url,
             data=json.dumps(data, cls=BaseEncoder),
-            headers={"Content-Type": "application/json",
-                     "Accept-Encoding": encoding},
+            headers={"Content-Type": "application/json", "Accept-Encoding": encoding},
             params=query_args,
             stream=~return_df,
         )
@@ -643,8 +641,7 @@ class MaterializatonClientV2(ClientBase):
         if return_df:
             with warnings.catch_warnings():
                 warnings.simplefilter(action="ignore", category=FutureWarning)
-                warnings.simplefilter(
-                    action="ignore", category=DeprecationWarning)
+                warnings.simplefilter(action="ignore", category=DeprecationWarning)
                 df = pa.deserialize(response.content)
                 if desired_resolution is None:
                     desired_resolution = self.desired_resolution
@@ -657,8 +654,7 @@ class MaterializatonClientV2(ClientBase):
                     vox_res = self.get_table_metadata(
                         table, datastack_name, materialization_version
                     )["voxel_resolution"]
-                    df = convert_position_columns(
-                        df, vox_res, desired_resolution)
+                    df = convert_position_columns(df, vox_res, desired_resolution)
             if metadata:
                 attrs = self._assemble_attributes(
                     tables,
@@ -768,8 +764,7 @@ class MaterializatonClientV2(ClientBase):
         response = self.session.post(
             url,
             data=json.dumps(data, cls=BaseEncoder),
-            headers={"Content-Type": "application/json",
-                     "Accept-Encoding": encoding},
+            headers={"Content-Type": "application/json", "Accept-Encoding": encoding},
             params=query_args,
             stream=~return_df,
         )
@@ -777,8 +772,7 @@ class MaterializatonClientV2(ClientBase):
         if return_df:
             with warnings.catch_warnings():
                 warnings.simplefilter(action="ignore", category=FutureWarning)
-                warnings.simplefilter(
-                    action="ignore", category=DeprecationWarning)
+                warnings.simplefilter(action="ignore", category=DeprecationWarning)
                 df = pa.deserialize(response.content)
 
             if metadata:
@@ -835,10 +829,8 @@ class MaterializatonClientV2(ClientBase):
             return filters, {}
         root_ids = np.unique(np.concatenate(root_ids))
 
-        filter_timed_end = self.cg_client.is_latest_roots(
-            root_ids, timestamp=timestamp)
-        filter_timed_start = self.cg_client.get_root_timestamps(
-            root_ids) < timestamp
+        filter_timed_end = self.cg_client.is_latest_roots(root_ids, timestamp=timestamp)
+        filter_timed_start = self.cg_client.get_root_timestamps(root_ids) < timestamp
         filter_timestamp = np.logical_and(filter_timed_start, filter_timed_end)
         if not np.all(filter_timestamp):
             roots_too_old = root_ids[~filter_timed_end]
@@ -871,8 +863,7 @@ class MaterializatonClientV2(ClientBase):
                             new_dict[col] = id_mapping["past_id_map"][root_ids]
                         else:
                             new_dict[col] = np.concatenate(
-                                [id_mapping["past_id_map"][v]
-                                    for v in root_ids]
+                                [id_mapping["past_id_map"][v] for v in root_ids]
                             )
                     else:
                         new_dict[col] = root_ids
@@ -900,8 +891,7 @@ class MaterializatonClientV2(ClientBase):
                 # use the future map to update rootIDs
                 if future_map is not None:
                     df[root_id_col].replace(future_map, inplace=True)
-                all_root_ids = np.append(
-                    all_root_ids, df[root_id_col].values.copy())
+                all_root_ids = np.append(all_root_ids, df[root_id_col].values.copy())
 
             uniq_root_ids = np.unique(all_root_ids)
 
@@ -935,8 +925,7 @@ class MaterializatonClientV2(ClientBase):
         logger.info(f"all_svid_lengths {all_svid_lengths}")
         with TimeIt("get_roots"):
             # find the up to date root_ids for those supervoxels
-            updated_root_ids = self.cg_client.get_roots(
-                all_svids, timestamp=timestamp)
+            updated_root_ids = self.cg_client.get_roots(all_svids, timestamp=timestamp)
             del all_svids
 
         # loop through the columns again replacing the root ids with their updated
@@ -949,7 +938,7 @@ class MaterializatonClientV2(ClientBase):
                 root_id_col = sv_col[: -len("supervoxel_id")] + "root_id"
                 root_ids = df[root_id_col].values.copy()
 
-                uroot_id = updated_root_ids[k: k + n_svids]
+                uroot_id = updated_root_ids[k : k + n_svids]
                 k += n_svids
                 root_ids[~is_latest_root] = uroot_id
                 # ran into an isssue with pyarrow producing read only columns
@@ -1124,8 +1113,7 @@ class MaterializatonClientV2(ClientBase):
         with TimeIt("deserialize"):
             with warnings.catch_warnings():
                 warnings.simplefilter(action="ignore", category=FutureWarning)
-                warnings.simplefilter(
-                    action="ignore", category=DeprecationWarning)
+                warnings.simplefilter(action="ignore", category=DeprecationWarning)
                 df = pa.deserialize(response.content)
                 if desired_resolution is not None:
                     df = df.copy()
@@ -1138,8 +1126,7 @@ class MaterializatonClientV2(ClientBase):
                         datastack_name=datastack_name,
                         version=materialization_version,
                     )["voxel_resolution"]
-                    df = convert_position_columns(
-                        df, vox_res, desired_resolution)
+                    df = convert_position_columns(df, vox_res, desired_resolution)
             if not split_positions:
                 concatenate_position_columns(df, inplace=True)
         # post process the dataframe to update all the root_ids columns
@@ -1193,9 +1180,10 @@ class MaterializatonClientV2(ClientBase):
         limit: int = None,
         offset: int = None,
         split_positions: bool = False,
+        desired_resolution: Iterable[float] = None,
+        materialization_version: int = None,
         synapse_table: str = None,
         datastack_name: str = None,
-        materialization_version: int = None,
         metadata: bool = True,
     ):
         """query synapses
@@ -1214,6 +1202,9 @@ class MaterializatonClientV2(ClientBase):
             offset (int, optional): number of synapses to offset query, Defaults to None (no offset).
             split_positions (bool, optional): whether to return positions as seperate x,y,z columns (faster)
                 defaults to False
+            desired_resolution : Iterable[float] or None, optional
+                If given, should be a list or array of the desired resolution you want queries returned in
+                useful for materialization queries.
             synapse_table (str, optional): synapse table to query. If None, defaults to self.synapse_table.
             datastack_name: (str, optional): datastack to query
             materialization_version (int, optional): version to query.
@@ -1260,6 +1251,7 @@ class MaterializatonClientV2(ClientBase):
             offset=offset,
             limit=limit,
             split_positions=split_positions,
+            desired_resolution=desired_resolution,
             materialization_version=materialization_version,
             timestamp=timestamp,
             datastack_name=datastack_name,
@@ -1275,7 +1267,9 @@ class MaterializatonClientV2(ClientBase):
         else:
             return df
 
-    def _assemble_attributes(self, tables, suffixes=None, desired_resolution=None, **kwargs):
+    def _assemble_attributes(
+        self, tables, suffixes=None, desired_resolution=None, **kwargs
+    ):
         if isinstance(tables, str):
             tables = [tables]
 


### PR DESCRIPTION
I'm trying to make it easier/more intuitive for users to setup tokens and support multiple databases.  This adds a new method for setting up a token which doesn't create a new one by default, and saves a token specific to the server by default, so now users will save and load those files as they interact with multiple servers and they can utilize the setup function either way. 