### PR TITLE
Move desired resolution server

### DIFF
--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -1586,7 +1586,10 @@ it will likely get removed in future versions. "
     ):
         if isinstance(tables, str):
             tables = [tables]
-
+        if isinstance(desired_resolution, str):
+            desired_resolution = np.array([
+                float(r) for r in desired_resolution.split(", ")
+            ])
         join_query = len(tables) > 1
 
         attrs = {

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -488,7 +488,7 @@ class MaterializatonClientV2(ClientBase):
             if isinstance(select_columns, list):
                 data["select_columns"] = select_columns
             elif isinstance(select_columns, dict):
-                data["select_map"] = select_columns
+                data["select_column_map"] = select_columns
             else:
                 raise ValueError(
                     "select columns should be a dictionary with tables as keys and values of column names in table (no suffixes)"

--- a/tests/test_materialization.py
+++ b/tests/test_materialization.py
@@ -139,7 +139,7 @@ class TestMatclient:
             body=pos_serialized.to_buffer().to_pybytes(),
             headers={
                 "content-type": "x-application/pyarrow",
-                "dataframe_resoluiont": "1, 1, 1",
+                "dataframe_resolution": "1, 1, 1",
             },
             match=[
                 responses.json_params_matcher(


### PR DESCRIPTION
This PR will allow the server to send back information about the dataframe_resolution is converted all spatial data to, and the table:column_name > dataframe_column name mapping that had to be used to alter the columns. 

It also moves over to defaulting to sending suffixes and select_columns as dictionaries rather than lists, though it will still send lists. 