### PR TITLE
Datastack to server map

### DIFF
--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -1,0 +1,39 @@
+import os
+import json
+from . import auth
+
+DEFAULT_LOCATION = auth.default_token_location
+DEFAULT_DATASTACK_FILE = 'cave_datastack_to_server_map.json'
+
+def read_map(filename = None):
+    if filename is None:
+        filename = os.path.join(DEFAULT_LOCATION, DEFAULT_DATASTACK_FILE)
+    try:
+        with open(os.path.expanduser(filename), 'r') as f:
+            data = json.load(f)
+        return data
+    except:
+        return {}
+
+def write_map(data, filename = None):
+    if filename is None:
+        filename = os.path.join(DEFAULT_LOCATION, DEFAULT_DATASTACK_FILE)
+    if not os.path.exists(DEFAULT_LOCATION):
+        os.makedirs( os.path.expanduser(DEFAULT_LOCATION)) 
+    with open(os.path.expanduser(filename), 'w') as f:
+        json.dump(data, f)
+    print("Updated stored datastack server map")
+
+def handle_server_address(datastack, server_address, filename=None, overwrite=False):
+    data = read_map(filename)
+    if server_address is not None:
+        if (datastack in data and overwrite) or datastack not in data:
+            data[datastack] = server_address
+            write_map(data, filename)
+        return server_address
+    else:
+        return data.get(datastack)
+
+def get_datastack_map(filename=None):
+    return read_map(filename)
+

--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -18,8 +18,8 @@ def read_map(filename = None):
 def write_map(data, filename = None):
     if filename is None:
         filename = os.path.join(DEFAULT_LOCATION, DEFAULT_DATASTACK_FILE)
-    if not os.path.exists(DEFAULT_LOCATION):
-        os.makedirs( os.path.expanduser(DEFAULT_LOCATION)) 
+    if not os.path.exists(os.path.expanduser(DEFAULT_LOCATION)):
+        os.makedirs(os.path.expanduser(DEFAULT_LOCATION)) 
     with open(os.path.expanduser(filename), 'w') as f:
         json.dump(data, f)
     print("Updated stored datastack server map")

--- a/caveclient/format_utils.py
+++ b/caveclient/format_utils.py
@@ -33,7 +33,6 @@ def format_graphene(objurl):
         objurl_out = None
     return objurl_out
 
-
 def format_cloudvolume(objurl):
     qry = urlparse(objurl)
     if qry.scheme == "graphene":

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -7,6 +7,7 @@ from .jsonservice import JSONService
 from .materializationengine import MaterializationClient
 from .l2cache import L2CacheClient
 from .endpoints import default_global_server_address
+from .datastack_lookup import handle_server_address
 
 DEFAULT_RETRIES = 3
 
@@ -29,6 +30,7 @@ class CAVEclient(object):
         pool_block=None,
         desired_resolution=None,
         info_cache=None,
+        write_server_cache=True,
     ):
         """A manager for all clients sharing common datastack and authentication information.
 
@@ -77,7 +79,13 @@ class CAVEclient(object):
             useful for materialization queries.
         info_cache: dict or None, optional
             Pre-computed info cache, bypassing the lookup of datastack info from the info service. Should only be used in cases where this information is cached and thus repetitive lookups can be avoided.
+        write_server_cache: bool, optional
+            If True, write the map between datastack and server address to a local cache file that is used to look up server addresses if not provided. Optional, defaults to True.
         """
+        server_address = handle_server_address(datastack_name, server_address, overwrite=write_server_cache)
+        if server_address is None:
+            raise ValueError('server_address must be provided or datastack_name must be provided with a valid server address in the server address cache')
+
         if global_only or datastack_name is None:
             return CAVEclientGlobal(
                 server_address=server_address,

--- a/caveclient/l2cache.py
+++ b/caveclient/l2cache.py
@@ -5,7 +5,6 @@ from .endpoints import (
 )
 from .auth import AuthClient
 import json
-import warnings
 
 server_key = "l2cache_server_address"
 
@@ -72,7 +71,6 @@ class L2CacheClientLegacy(ClientBase):
             pool_block=pool_block,
             over_client=over_client,
         )
-        warnings.warn("L2Cache is in an experimental stage", UserWarning)
         self._default_url_mapping["table_id"] = table_name
         self._available_attributes = None
 


### PR DESCRIPTION
Small quality of life feature: Store a map between datastack_name and the server_address in the ~/.cloudvolume directory. Accidentally built on top of the L2 warning removal, which is also a QoL issue and could be removed or just merged as one.
