### PR TITLE
Datastack to server map

### DIFF
--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -1,6 +1,8 @@
 import os
 import json
 from . import auth
+import logging
+logger = logging.getLogger(__name__)
 
 DEFAULT_LOCATION = auth.default_token_location
 DEFAULT_DATASTACK_FILE = 'cave_datastack_to_server_map.json'
@@ -29,7 +31,7 @@ def handle_server_address(datastack, server_address, filename=None, write=False)
         if write and server_address != data.get(datastack):
             data[datastack] = server_address
             write_map(data, filename)
-            print(f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datatsack '{datastack}'")
+            logger.warning(f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datatsack '{datastack}'")
         return server_address
     else:
         return data.get(datastack)
@@ -52,6 +54,6 @@ def reset_server_address_cache(datastack, filename=None):
         datastack = [datastack]
     for ds in datastack:
         data.pop(ds, None)
-        print(f'Wiping {ds} from datastack-to-server cache')
+        logger.warning(f"Wiping '{ds}' from datastack-to-server cache")
     write_map(data, filename)
     

--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -22,18 +22,36 @@ def write_map(data, filename = None):
         os.makedirs(os.path.expanduser(DEFAULT_LOCATION)) 
     with open(os.path.expanduser(filename), 'w') as f:
         json.dump(data, f)
-    print("Updated stored datastack server map")
 
-def handle_server_address(datastack, server_address, filename=None, overwrite=False):
+def handle_server_address(datastack, server_address, filename=None, write=False):
     data = read_map(filename)
     if server_address is not None:
-        if (datastack in data and overwrite) or datastack not in data:
+        if write and server_address != data.get(datastack):
             data[datastack] = server_address
             write_map(data, filename)
+            print(f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datatsack '{datastack}'")
         return server_address
     else:
         return data.get(datastack)
 
-def get_datastack_map(filename=None):
+def get_datastack_cache(filename=None):
     return read_map(filename)
 
+def reset_server_address_cache(datastack, filename=None):
+    """Remove one or more datastacks from the datastack-to-server cache.
+
+    Parameters
+    ----------
+    datastacks : str or list of str, optional
+        Datastack names to remove from the cache, by default None
+    filename : str, optional
+        Name of the cache file, by default None
+    """
+    data = read_map(filename)
+    if isinstance(datastack, str):
+        datastack = [datastack]
+    for ds in datastack:
+        data.pop(ds, None)
+        print(f'Wiping {ds} from datastack-to-server cache')
+    write_map(data, filename)
+    

--- a/caveclient/datastack_lookup.py
+++ b/caveclient/datastack_lookup.py
@@ -31,7 +31,7 @@ def handle_server_address(datastack, server_address, filename=None, write=False)
         if write and server_address != data.get(datastack):
             data[datastack] = server_address
             write_map(data, filename)
-            logger.warning(f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datatsack '{datastack}'")
+            logger.warning(f"Updated datastack-to-server cache — '{server_address}' will now be used by default for datastack '{datastack}'")
         return server_address
     else:
         return data.get(datastack)

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -83,8 +83,6 @@ class CAVEclient(object):
             If True, write the map between datastack and server address to a local cache file that is used to look up server addresses if not provided. Optional, defaults to True.
         """
         server_address = handle_server_address(datastack_name, server_address, overwrite=write_server_cache)
-        if server_address is None:
-            raise ValueError('server_address must be provided or datastack_name must be provided with a valid server address in the server address cache')
 
         if global_only or datastack_name is None:
             return CAVEclientGlobal(

--- a/caveclient/frameworkclient.py
+++ b/caveclient/frameworkclient.py
@@ -82,7 +82,7 @@ class CAVEclient(object):
         write_server_cache: bool, optional
             If True, write the map between datastack and server address to a local cache file that is used to look up server addresses if not provided. Optional, defaults to True.
         """
-        server_address = handle_server_address(datastack_name, server_address, overwrite=write_server_cache)
+        server_address = handle_server_address(datastack_name, server_address, write=write_server_cache)
 
         if global_only or datastack_name is None:
             return CAVEclientGlobal(

--- a/docs/guide/framework.rst
+++ b/docs/guide/framework.rst
@@ -56,7 +56,22 @@ This gives you access to the full range of client functions.
 .. code:: python
 
     client = CAVEclient(datastack_name='my_datastack')
-    
+
+Using Other Server Addresses
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If your data is hosted by a different global server, you specify its address when initializing the client.
+
+.. code:: python
+
+    client = CAVEclient(datastack_name='my_datastack', server_address='http://global.myserver.com')
+
+By default, if you pass both a server address and a datastack, the client will store the mapping from datastack to server address
+in the same location as the default for authentication tokens.
+Once stored, the client will automatically use the correct server address for the datastack if none is provided.
+You can override storing the server address by passing ``write_server_address=False``.
+Datastacks can be removed from the cache using `caveclient.datastack_lookup.reset_server_address_cache(datastack_name)`.
+
 
 Accessing specific clients
 ~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,5 +38,5 @@ def myclient():
 
     responses.add(responses.GET, url, json=test_info, status=200)
 
-    client = CAVEclient(TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER)
+    client = CAVEclient(TEST_DATASTACK, server_address=TEST_GLOBAL_SERVER, write_server_cache=False)
     return client


### PR DESCRIPTION
Several tweaks:
1. The server map never errors, passing any Nones along to the client to handle. This restores existing default behavior.
2. Tests do not add an entry to the cache file
3. Docs describe the cache
4. Users/logs get notified when the cache changes
