### PR TITLE
Fix division by zero

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -888,6 +888,8 @@ class ChunkedGraphClientV1(ClientBase):
         stop_layer = max(1, stop_layer)
         
         chunks_orig = self.get_leaves(root_id, stop_layer=stop_layer)
+        if not chunks_orig:
+            return [] if return_all else None
         chunk_list = np.array(
             [
                 len(


### PR DESCRIPTION
Caught when trying to map few root ids to 630:

candidates = cave_client.chunkedgraph.suggest_latest_roots(rid, mat_timestamp, return_all=True)
  File "/Users/arie/mambaforge/envs/codex/lib/python3.9/site-packages/caveclient/chunkedgraph.py", line 892, in suggest_latest_roots
    [
  File "/Users/arie/mambaforge/envs/codex/lib/python3.9/site-packages/caveclient/chunkedgraph.py", line 893, in <listcomp>
    len(
ZeroDivisionError: division by zero
params: 720575940616772438 with 2023-03-21 08:10:01.194185+00:00 (v630)
same if return_all=False