### PR TITLE
fixes issues with lineage graph filtering with client side filtering

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -786,10 +786,8 @@ class ChunkedGraphClientV1(ClientBase):
         timestamp_past = self.get_root_timestamps(root_id).min()
 
         lineage_graph = self.get_lineage_graph(
-            root_id, timestamp_past=timestamp_past, timestamp_future=timestamp_future
+            root_id, timestamp_past=timestamp_past, timestamp_future=timestamp_future, as_nx_graph=True
         )
-
-        lineage_graph = nx.node_link_graph(lineage_graph)
 
         out_degree_dict = dict(lineage_graph.out_degree)
         nodes = np.array(list(out_degree_dict.keys()))

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -814,10 +814,12 @@ class ChunkedGraphClientV1(ClientBase):
         if timestamp_future is not None:
             logger.warning("timestamp_future is deprecated, use timestamp instead")
             timestamp = timestamp_future
-
+        
         if timestamp is None:
             timestamp = datetime.datetime.now(datetime.timezone.utc)
-
+        elif timestamp.tzinfo is None:
+            timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
+            
         # or if timestamp_root is less than timestamp_future
         if (timestamp is None) or (timestamp_root < timestamp):
             lineage_graph = self.get_lineage_graph(

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -813,8 +813,7 @@ class ChunkedGraphClientV1(ClientBase):
         timestamp_root = self.get_root_timestamps(root_id).min()
         if timestamp_future is not None:
             logger.warning(
-                "timestamp_future is deprecated, use timestamp instead",
-                DeprecationWarning,
+                "timestamp_future is deprecated, use timestamp instead"
             )
             timestamp = timestamp_future
 

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -84,11 +84,7 @@ def root_id_int_list_check(
     root_id,
     make_unique=False,
 ):
-    if (
-        isinstance(root_id, int)
-        or isinstance(root_id, np.uint64)
-        or isinstance(root_id, np.int64)
-    ):
+   isinstance(root_id, (int, np.uint64, np.int64)):
         root_id = [root_id]
     elif isinstance(root_id, str):
         try:
@@ -737,8 +733,10 @@ class ChunkedGraphClientV1(ClientBase):
             if True, a networkx graph is returned
         exclude_links_to_future: bool
             if True, links from nodes before timestamp_future to after timestamp_future are removed
+            if False, the link(s) which has one node before timestamp and one node after timestamp is kept
         exclude_links_to_past: bool
             if True, links from nodes before timestamp_past to after timestamp_past are removed
+            if False, the link(s) which has one node before timestamp and one node after timestamp is kept
 
         Returns
         -------

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -812,9 +812,7 @@ class ChunkedGraphClientV1(ClientBase):
 
         timestamp_root = self.get_root_timestamps(root_id).min()
         if timestamp_future is not None:
-            logger.warning(
-                "timestamp_future is deprecated, use timestamp instead"
-            )
+            logger.warning("timestamp_future is deprecated, use timestamp instead")
             timestamp = timestamp_future
 
         if timestamp is None:
@@ -938,7 +936,7 @@ class ChunkedGraphClientV1(ClientBase):
         return_fraction_overlap : bool, optional
             If True, return all fractions sorted by most overlap to least, by default False. If False, only the topmost value is returned.
         """
-        curr_ids = self.get_latest_roots(root_id, timestamp_future=timestamp)
+        curr_ids = self.get_latest_roots(root_id, timestamp=timestamp)
 
         if root_id in curr_ids:
             if return_all:

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -819,7 +819,7 @@ class ChunkedGraphClientV1(ClientBase):
             timestamp = datetime.datetime.now(datetime.timezone.utc)
         elif timestamp.tzinfo is None:
             timestamp = timestamp.replace(tzinfo=datetime.timezone.utc)
-            
+
         # or if timestamp_root is less than timestamp_future
         if (timestamp is None) or (timestamp_root < timestamp):
             lineage_graph = self.get_lineage_graph(

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -204,7 +204,7 @@ class ChunkedGraphClientV1(ClientBase):
             if self._default_timestamp is not None:
                 return self._default_timestamp
             else:
-                return datetime.datetime.utcnow()
+                return datetime.datetime.now(datetime.timezone.utc)
         else:
             return timestamp
 
@@ -816,11 +816,10 @@ class ChunkedGraphClientV1(ClientBase):
             timestamp = timestamp_future
 
         if timestamp is None:
-            timestamp = datetime.datetime.utcnow()
+            timestamp = datetime.datetime.now(datetime.timezone.utc)
 
         # or if timestamp_root is less than timestamp_future
-
-        if timestamp is None or timestamp_root < timestamp:
+        if (timestamp is None) or (timestamp_root < timestamp):
             lineage_graph = self.get_lineage_graph(
                 root_id,
                 timestamp_past=timestamp_root,
@@ -1114,14 +1113,16 @@ class ChunkedGraphClientV1(ClientBase):
     def get_delta_roots(
         self,
         timestamp_past: datetime.datetime,
-        timestamp_future: datetime.datetime = datetime.datetime.utcnow(),
+        timestamp_future: datetime.datetime = datetime.datetime.now(
+            datetime.timezone.utc
+        ),
     ):
         """get the list of roots that have changed between timetamp_past and timestamp_future
 
 
         Args:
             timestamp_past (datetime.datetime): past timepoint to query
-            timestamp_future (datetime.datetime, optional): future timepoint to query. Defaults to datetime.datetime.utcnow().
+            timestamp_future (datetime.datetime, optional): future timepoint to query. Defaults to datetime.datetime.now(datetime.timezone.utc).
 
         Returns:
             old_roots (np.ndarray): roots that have expired in that interval

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -84,7 +84,7 @@ def root_id_int_list_check(
     root_id,
     make_unique=False,
 ):
-   if isinstance(root_id, (int, np.uint64, np.int64)):
+    if isinstance(root_id, (int, np.uint64, np.int64)):
         root_id = [root_id]
     elif isinstance(root_id, str):
         try:
@@ -812,7 +812,7 @@ class ChunkedGraphClientV1(ClientBase):
         if timestamp_future is not None:
             logger.warning("timestamp_future is deprecated, use timestamp instead")
             timestamp = timestamp_future
-        
+
         if timestamp is None:
             timestamp = datetime.datetime.now(datetime.timezone.utc)
         elif timestamp.tzinfo is None:

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -84,7 +84,7 @@ def root_id_int_list_check(
     root_id,
     make_unique=False,
 ):
-   isinstance(root_id, (int, np.uint64, np.int64)):
+   if isinstance(root_id, (int, np.uint64, np.int64)):
         root_id = [root_id]
     elif isinstance(root_id, str):
         try:

--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -111,7 +111,7 @@ def concatenate_position_columns(df, inplace=False):
 
 def convert_timestamp(ts: datetime):
     if ts == "now":
-        ts = datetime.utcnow()
+        ts = datetime.now(timezone.utc)
 
     if isinstance(ts, datetime):
         if ts.tzinfo is None:
@@ -1181,7 +1181,7 @@ class MaterializatonClientV2(ClientBase):
             allow_missing_lookups (bool, optional): If there are annotations without supervoxels and rootids yet, allow results. Defaults to False.
             random_sample: (int, optional) : if given, will do a tablesample of the table to return that many annotations
         Example:
-         live_live_query("table_name",datetime.datetime.utcnow(),
+         live_live_query("table_name",datetime.datetime.now(datetime.timezone.utc),
             joins=[[table_name, table_column, joined_table, joined_column],
                      [joined_table, joincol2, third_table, joincol_third]]
             suffixes={
@@ -1350,7 +1350,7 @@ it will likely get removed in future versions. "
         Args:
             table: 'str'
             timestamp (datetime.datetime): time to materialize (in utc)
-                pass datetime.datetime.utcnow() for present time
+                pass datetime.datetime.now(datetime.timezone.utc) for present time
             filter_in_dict (dict , optional):
                 keys are column names, values are allowed entries.
                 Defaults to None.
@@ -1850,7 +1850,7 @@ class MaterializatonClientV3(MaterializatonClientV2):
             allow_invalid_root_ids (bool, optional): If True, ignore root ids not valid at the given timestamp, otherwise raise an Error. Defaults to False.
             random_sample (int, optional): If given, will do a tablesample of the table to return that many annotations
         Example:
-         live_live_query("table_name",datetime.datetime.utcnow(),
+         live_live_query("table_name",datetime.datetime.now(datetime.timezone.utc),
             joins=[[table_name, table_column, joined_table, joined_column],
                      [joined_table, joincol2, third_table, joincol_third]]
             suffixes={

--- a/docs/guide/materialization.rst
+++ b/docs/guide/materialization.rst
@@ -212,7 +212,7 @@ that is more recent that the most recent version available.  For convience, you 
 
 
 to automatically update the results of your query to a time in the future, such as now.
-For example, to pass now, use ```datetime.datetime.utcnow```.  Note all timestamps are in UTC
+For example, to pass now, use ```datetime.datetime.now(datetime.timezone.utc)```.  Note all timestamps are in UTC
 throughout the codebase. 
 
 .. code:: python
@@ -220,7 +220,7 @@ throughout the codebase.
     import datetime
     synapse_table = client.info.get_datastack_info()['synapse_table']
     df=client.materialize.live_query(synapse_table,
-                                      datetime.datetime.utcnow(),
+                                      datetime.datetime.now(datetime.timezone.utc),
                                       filter_equal_dict = {'post_pt_root_id': MYID})
 
 This will raise an ValueError exception if the IDs passed in your filters are not valid at the timestamp given
@@ -232,11 +232,11 @@ You can also pass a timestamp directly to query_table and it will call live_quer
     import datetime
     synapse_table = client.info.get_datastack_info()['synapse_table']
     df=client.materialize.query_table(synapse_table,
-                                      timestamp=datetime.datetime.utcnow(),
+                                      timestamp=datetime.datetime.now(datetime.timezone.utc),
                                       filter_equal_dict = {'post_pt_root_id': MYID})
 
 
-Also, keep in mind if you run multiple queries and at each time pass ``datetime.datetime.utcnow()``,
+Also, keep in mind if you run multiple queries and at each time pass ``datetime.datetime.now(datetime.timezone.utc)``,
 there is no gauruntee that the IDs will be consistent from query to query, as proofreading might be happening
 at any time.  For larger scale analysis constraining oneself to a materialized version will ensure consistent results.
 
@@ -312,7 +312,7 @@ The one required argument for ``live_query`` is the timestamp.
     nuc_df = client.materialize.tables.nucleus_detection_v0(
         id=my_ids
     ).live_query(
-        timestamp=datetime.datetime.utcnow(),
+        timestamp=datetime.datetime.now(datetime.timezone.utc),
     )
 
 The live query functions have similar but slightly different arguments: ``timestamp`` (required), ``offset``, ``limit``, ``split_positions``,

--- a/tests/test_chunkedgraph.py
+++ b/tests/test_chunkedgraph.py
@@ -47,7 +47,7 @@ class TestChunkedgraph:
         url = chunkedgraph_endpoints_v1["get_roots"].format_map(endpoint_mapping)
         svids = np.array([97557743795364048, 75089979126506763], dtype=np.uint64)
         root_ids = np.array([864691135217871271, 864691135566275148], dtype=np.uint64)
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         query_d = package_timestamp(now)
         qurl = url + "?" + urlencode(query_d)
         responses.add(
@@ -231,7 +231,7 @@ class TestChunkedgraph:
         endpoint_mapping = self._default_endpoint_map
         url = chunkedgraph_endpoints_v1["delta_roots"].format_map(endpoint_mapping)
 
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         timestamp_past = now - datetime.timedelta(days=1)
         query_d = package_timestamp(timestamp_past, name="timestamp_past")
         query_d.update(package_timestamp(now, name="timestamp_future"))
@@ -434,7 +434,7 @@ class TestChunkedgraph:
                 "864691136577570580": [864691136721486702, 864691133958789149],
             },
         }
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         timestamp_past = now - datetime.timedelta(days=7)
 
         query_d = package_timestamp(timestamp_past, name="timestamp_past")
@@ -470,7 +470,7 @@ class TestChunkedgraph:
         url = chunkedgraph_endpoints_v1["handle_lineage_graph"].format_map(
             endpoint_mapping
         )
-        now = datetime.datetime.utcnow()
+        now = datetime.datetime.now(datetime.timezone.utc)
         timestamp_past = now - datetime.timedelta(days=7)
 
         query_d = package_timestamp(timestamp_past, name="timestamp_past")


### PR DESCRIPTION
This is necessary on v1 at least where timestamp filtering does not appear to give the result one would want.

```root_id = 720575940616772438
root_ts = client.chunkedgraph.get_root_timestamps(root_id)[0]
mat_timestamp=client.materialize.get_version_metadata(version=630)['time_stamp']
lineage_graph= client.chunkedgraph.get_lineage_graph(root_id, timestamp_past=root_ts,
                                                     timestamp_future=mat_timestamp)
print(f'root_ts: {root_ts} mat_timestamp: {mat_timestamp}')
for node in lineage_graph['nodes']:
    node_ts= datetime.datetime.fromtimestamp(node['timestamp'])
    node_ts=node_ts.astimezone(datetime.timezone.utc)
    if ( (node_ts<mat_timestamp) or (node_ts>root_ts)):
        print(node, node_ts)
```
        
        