### PR TITLE
`chunkedgraph` module documentation improvements and standardization

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -284,7 +284,7 @@ class ChunkedGraphClientV1(ClientBase):
         Parameters
         ----------
         root_id : int
-            Object root id to look up
+            Object root ID to look up.
 
         Returns
         -------
@@ -319,7 +319,7 @@ class ChunkedGraphClientV1(ClientBase):
         include_undo: bool = True,
         timestamp_end: datetime.datetime = None,
     ):
-        """Get operation details for a User ID.
+        """Get operation details for a user ID.
 
         Parameters
         ----------
@@ -335,7 +335,7 @@ class ChunkedGraphClientV1(ClientBase):
         Returns
         -------
         pd.DataFrame
-            Dataframe with the following columns:
+            DataFrame with the following columns:
 
             "operation_id": int
                 Identifier for the operation.
@@ -454,8 +454,7 @@ class ChunkedGraphClientV1(ClientBase):
         return np.int64(handle_response(response)["leaf_ids"])
 
     def do_merge(self, supervoxels, coords, resolution=(4, 4, 40)):
-        """Perform a merge on the chunkeded graph.
-
+        """Perform a merge on the chunked graph.
 
         Parameters
         ----------
@@ -730,7 +729,6 @@ class ChunkedGraphClientV1(ClientBase):
         return centroids, l2_path, failed_l2_ids
 
     def get_subgraph(self, root_id, bounds):
-        # re-write the old docstring below using better grammar and numpydoc formatting
         """Get subgraph of root id within a bounding box.
 
         Parameters
@@ -1088,7 +1086,8 @@ class ChunkedGraphClientV1(ClientBase):
         return_all=False,
         return_fraction_overlap=False,
     ):
-        """Suggest latest roots for a given root id, based on overlap of component
+        """
+        Suggest latest roots for a given root id, based on overlap of component
         chunk IDs. Note that edits change chunk IDs, and so this effectively measures
         the fraction of unchanged chunks at a given chunk layer, which sets the size
         scale of chunks. Higher layers are coarser.

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -389,8 +389,8 @@ class ChunkedGraphClientV1(ClientBase):
             "operation_id": int
                 Identifier for the operation.
             "timestamp": int
-                Timestamp of the operation.
-                # TODO what format is this in?
+                Timestamp of the operation, provided in *milliseconds*. To convert to
+                datetime, use ``datetime.datetime.utcfromtimestamp(timestamp/1000)``.
             "user_id": int
                 User who performed the operation.
             "before_root_ids: list of int

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -327,7 +327,7 @@ class ChunkedGraphClientV1(ClientBase):
         """
         Get operation details for a user ID. Currently, this is only available to
         admins.
-        
+
 
         Parameters
         ----------
@@ -834,13 +834,11 @@ class ChunkedGraphClientV1(ClientBase):
                 points placed by the user when specifying the operation. Each sink
                 coordinate is a list of three integers (x, y, z), corresponding to
                 spatial coordinates in segmentation voxel space.
-                # TODO make sure this is the correct specification
             "source_coords": list of list of int
                 List of source coordinates for this operation. The source is one of the
                 points placed by the user when specifying the operation. Each source
                 coordinate is a list of three integers (x, y, z), corresponding to
                 spatial coordinates in segmentation voxel space.
-                # TODO make sure this is the correct specification
             "timestamp": str
                 Timestamp of the operation.
             "user": str

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -384,6 +384,11 @@ class ChunkedGraphClientV1(ClientBase):
         ----------
         root_ids : list of int
             Object root IDs to look up.
+        filtered : bool
+            Whether to filter the change log to only include splits and merges which
+            affect the final state of the object (`filtered=True`), as opposed to
+            including edit history for objects which as some point were split from
+            the query objects in `root_ids` (`filtered=False`). Defaults to True.
 
         Returns
         -------

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -821,9 +821,10 @@ class ChunkedGraphClientV1(ClientBase):
             values are a dictionary of operation info for the operation. These
             dictionaries contain the following keys:
 
-            "added_edges": list of list of int
-                List of edges added by this operation. Each edge is a list of two node
-                IDs (source and target).
+            "added_edges"/"removed_edges": list of list of int
+                List of edges added (if a merge) or removed (if a split) by this 
+                operation. Each edge is a list of two supervoxel IDs (source and 
+                target).
             "roots": list of int
                 List of root IDs that were created by this operation.
             "sink_coords": list of list of int

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -494,8 +494,8 @@ class ChunkedGraphClientV1(ClientBase):
         Returns
         -------
         dict
-        # TODO not actually sure the return type here
         """
+        # TODO clarify what the return is here
         endpoint_mapping = self.default_url_mapping
         url = self._endpoints["undo"].format_map(endpoint_mapping)
 

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -324,7 +324,10 @@ class ChunkedGraphClientV1(ClientBase):
         include_undo: bool = True,
         timestamp_end: datetime.datetime = None,
     ):
-        """Get operation details for a user ID.
+        """
+        Get operation details for a user ID. Currently, this is only available to
+        admins.
+        
 
         Parameters
         ----------
@@ -340,7 +343,7 @@ class ChunkedGraphClientV1(ClientBase):
         Returns
         -------
         pd.DataFrame
-            DataFrame with the following columns:
+            DataFrame including the following columns:
 
             "operation_id": int
                 Identifier for the operation.
@@ -348,7 +351,6 @@ class ChunkedGraphClientV1(ClientBase):
                 Timestamp of the operation.
             "user_id": int
                 User who performed the operation.
-            # TODO not actually sure what the rest of the outputs are, not an admin
         """
 
         endpoint_mapping = self.default_url_mapping

--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -285,6 +285,11 @@ class ChunkedGraphClientV1(ClientBase):
         ----------
         root_id : int
             Object root ID to look up.
+        filtered : bool
+            Whether to filter the change log to only include splits and merges which
+            affect the final state of the object (`filtered=True`), as opposed to
+            including edit history for objects which as some point were split from
+            the query object `root_id` (`filtered=False`). Defaults to True.
 
         Returns
         -------


### PR DESCRIPTION
## Summary
- Added documentation for some returns which have a dictionary with many fields or dataframe etc.
   - This was my main reason for this PR, as a new user I just found the meaning of many of these kinds of returns opaque.
   -  This could probably still be improved. I took a stab at documenting these fields but if I could be wrong, feel free to add corrections. 
- Made everything use numpydoc, previously it was a mix 
- Used a more standard way of specifying types (see numpydoc) 
- Clarified references to actual variables in the docstrings with backticks 
- Added a few missing param descriptions 
- Tried to standardize nomenclature a bit, at least in this module

## TODO 
- [x] fix remaining inline TODOs about clarifying units
   - asked for feedback on a couple 
- [x] build docs locally to test