### PR TITLE
Fix ngl state encoding

### DIFF
--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -268,6 +268,8 @@ l2cache_api_versions = {1: l2cache_endpoints_v1}
 # ------ Neuroglancer endpoints
 # -------------------------------
 
+fallback_ngl_endpoint = "https://neuroglancer.neuvue.io/"
 ngl_endpoints_common = {
-    'get_info': "{ngl_url}/version.json"
+    'get_info': "{ngl_url}/version.json",
+    'fallback_ngl_url': fallback_ngl_endpoint,
 }

--- a/caveclient/endpoints.py
+++ b/caveclient/endpoints.py
@@ -263,3 +263,11 @@ l2cache_endpoints_v1 = {
 }
 
 l2cache_api_versions = {1: l2cache_endpoints_v1}
+
+# -------------------------------
+# ------ Neuroglancer endpoints
+# -------------------------------
+
+ngl_endpoints_common = {
+    'get_info': "{ngl_url}/version.json"
+}

--- a/caveclient/jsonservice.py
+++ b/caveclient/jsonservice.py
@@ -189,7 +189,7 @@ class JSONServiceV1(ClientBase):
         Parameters
         ----------
         json_state : dict
-            JSON-formatted Neuroglancer state
+            Dict representation of a neuroglancer state 
         state_id : int
             ID of a JSON state uploaded to the state service.
             Using a state_id is an admin feature.


### PR DESCRIPTION
Various fixes for better handling neuroglancer states.

* Fix json encoding for state server upload to make integers encoded as strings, as neuroglancer expects.
* Add `version.json` endpoint for a neuroglancer URL to get build info.
* Add middleauth to state service URL endpoints for Cave Explorer deployments.
* Use neuroglancer version endpoint to guess target site deployment (to use `middleauth+` prefix or not) if not specified. 