### PR TITLE
add static url and local save

### DIFF
--- a/caveclient/jsonservice.py
+++ b/caveclient/jsonservice.py
@@ -241,7 +241,7 @@ class JSONServiceV1(ClientBase):
         -------
         None
         """
-        if os.exists(filename) and not overwrite:
+        if os.path.exists(filename) and not overwrite:
             raise ValueError("File exists and overwrite is False")
         with open(filename, "w") as f:
             json.dump(json_state, f, default=neuroglancer_json_encoder)


### PR DESCRIPTION
Two features for handling states.

1) Add a local save file. The main advantage here is just passing through the neuroglancer parser, but it also makes the state client a one-stop shop for handling state dictionaries.

2) Add a boolean `static_url` argument to `build_neuroglancer_url`. This will treat the first argument as a fully formed URL on its own, making it easy to build links to static sources through whatever formatting is needed.