### PR TITLE
checks in get_latest_roots that all IDs are current

### DIFF
--- a/caveclient/chunkedgraph.py
+++ b/caveclient/chunkedgraph.py
@@ -1009,7 +1009,9 @@ class ChunkedGraphClientV1(ClientBase):
             out_degree_dict = dict(lineage_graph.out_degree)
             nodes = np.array(list(out_degree_dict.keys()))
             out_degrees = np.array(list(out_degree_dict.values()))
-            return nodes[out_degrees == 0]
+            out_degree_nodes = nodes[out_degrees == 0]
+            are_they_current = self.is_latest_roots(out_degree_nodes,timestamp=timestamp)
+            return out_degree_nodes[are_they_current]
         else:
             # then timestamp is in fact in the past
             lineage_graph = self.get_lineage_graph(
@@ -1021,7 +1023,9 @@ class ChunkedGraphClientV1(ClientBase):
             in_degree_dict = dict(lineage_graph.in_degree)
             nodes = np.array(list(in_degree_dict.keys()))
             in_degrees = np.array(list(in_degree_dict.values()))
-            return nodes[in_degrees == 0]
+            in_degree_nodes = nodes[in_degrees == 0]
+            are_they_current = self.is_latest_roots(in_degree_nodes,timestamp=timestamp)
+            return in_degree_nodes[are_they_current]
 
     def get_original_roots(self, root_id, timestamp_past=None):
         """Returns root IDs that are the latest successors of a given root ID.


### PR DESCRIPTION
In some cases where a change has been made to a non-current version of the neuron, IDs that are not current IDs can be returned by get_latest_roots(). Example:
```
>>> roots = client.chunkedgraph.get_latest_roots(648518346511326005)
>>> roots
array([648518346490738685, 648518346490090970, 648518346487824596,
       648518346478115029, 648518346491690920, 648518346493870449,
       648518346494682679, 648518346496428629, 648518346486444448,
       648518346467095022, 648518346504152360, 648518346494330759,
       648518346499567451])
>>> client.chunkedgraph.is_latest_roots(roots)
array([ True,  True,  True,  True,  True,  True, False,  True,  True,
       False,  True,  True,  True])
```

this can lead to suggest_latest_roots() also suggesting an ID that is not current:
```
>>> client.chunkedgraph.suggest_latest_roots(648518346511326005)
648518346494682679
>>> client.chunkedgraph.is_latest_roots(648518346494682679)
array([False])
```

This small alteration adds a check for these IDs and removes them.