### PR TITLE
Fix wrong parameter name for `filter_spatial_dict` in `query_table`

### DIFF
--- a/caveclient/materializationengine.py
+++ b/caveclient/materializationengine.py
@@ -636,7 +636,7 @@ class MaterializatonClientV2(ClientBase):
             filter_equal_dict (dict, optional):
                 inner layer: keys are column names, values are specified entry.
                 Defaults to None.
-            filter_spatial (dict, optional):
+            filter_spatial_dict (dict, optional):
                 inner layer: keys are column names, values are bounding boxes
                              as [[min_x, min_y,min_z],[max_x, max_y, max_z]]
                              Expressed in units of the voxel_resolution of this dataset.


### PR DESCRIPTION
Docs showed this parameter as `filter_spatial`, caused me some confusion (see https://github.com/seung-lab/CAVEclient/issues/137)